### PR TITLE
Add notice block

### DIFF
--- a/posts/test-post-five.md
+++ b/posts/test-post-five.md
@@ -5,13 +5,28 @@ title: A fly does not make any sense.
 
 # A fly does not make any sense.
 
+<div class="notice info">
+  <h3>Info notice block</h3>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer finibus tempor metus, eu condimentum ex vulputate at. Sed fringilla non.</p>
+</div>
+
 ## First subheading
 
 Cras dictum urna id arcu sollicitudin sagittis. Sed sit amet est in ipsum pellentesque vestibulum sed non nunc. Nulla aliquet mi erat, eu porta tortor egestas quis. Morbi sodales mattis ipsum ut convallis. Duis in mattis est, in rhoncus massa. Suspendisse eu neque ut diam consequat rhoncus et auctor libero. Aenean iaculis facilisis diam vitae ornare. Duis tincidunt finibus diam at aliquam. Sed ut nunc laoreet, malesuada dolor sit amet, porttitor nisi. Aenean bibendum, eros nec convallis pharetra, nisl mi feugiat elit, quis fringilla enim ipsum et ante.
 
+<div class="notice warning">
+  <h3>Warning notice block</h3>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer finibus tempor metus, eu condimentum ex vulputate at. Sed fringilla non.</p>
+</div>
+
 ## Second subheading
 
 Donec et ante a lorem convallis euismod quis in sapien. Donec consectetur scelerisque dolor id commodo. Ut sapien ex, facilisis et est id, ultricies sagittis metus. Sed interdum placerat turpis a tempus. Praesent vitae dolor nulla. Phasellus sed ultrices eros. Nullam rhoncus felis at urna euismod, sit amet tincidunt risus facilisis. Aliquam erat volutpat. Nam sodales, dui a luctus mollis, tellus lorem aliquam tortor, at mollis ipsum quam eget purus. Donec quis velit mauris. In imperdiet urna tortor, vel gravida sem fringilla eu. Mauris ultrices urna mauris, vitae eleifend nisl scelerisque eu.
+
+<div class="notice success">
+  <h3>Success notice block</h3>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer finibus tempor metus, eu condimentum ex vulputate at. Sed fringilla non.</p>
+</div>
 
 Mauris faucibus laoreet ullamcorper. Duis et urna non ligula facilisis suscipit. Nulla accumsan, nunc non tincidunt viverra, nisl odio fringilla est, ac tincidunt justo est ut ipsum. Nunc efficitur diam a blandit accumsan. Proin dictum purus eget nisl gravida egestas. Maecenas egestas eleifend nibh, eu accumsan erat pretium a. Morbi mollis velit et malesuada accumsan. Duis eget ligula bibendum, suscipit orci sed, gravida purus.
 
@@ -35,5 +50,10 @@ john.greet()
 ## Third subheading
 
 In feugiat id enim ut cursus. Vivamus vitae euismod nisi. Curabitur lacinia arcu ut nibh placerat, ac posuere elit eleifend. Pellentesque placerat, risus sed sagittis pharetra, nunc nisl dictum libero, sit amet pharetra erat nisl id nisi. Phasellus sit amet turpis est. Ut gravida risus ac hendrerit dapibus. Suspendisse pulvinar pretium pharetra. Integer ac mauris et est bibendum dapibus.
+
+<div class="notice danger">
+  <h3>Danger notice block</h3>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer finibus tempor metus, eu condimentum ex vulputate at. Sed fringilla non.</p>
+</div>
 
 Aliquam erat volutpat. Suspendisse efficitur ullamcorper risus vel feugiat. Integer eu accumsan enim. Sed aliquam ipsum tortor. Nulla nec magna dapibus, aliquet nibh at, hendrerit dui. Fusce at nunc justo. Donec bibendum ipsum sit amet luctus finibus.

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -79,7 +79,3 @@
 .post .notice.danger h3 {
   color: var(--danger);
 }
-
-/* .post .notice p:last-of-type {
-  margin-bottom: unset;
-} */

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -26,6 +26,9 @@
   font-size: 1.6rem;
   color: var(--text-main);
   line-height: 1.75;
+}
+
+.post p:not(:last-of-type) {
   margin-bottom: 2rem;
 }
 
@@ -35,3 +38,48 @@
   border-radius: 1.5rem;
   background-color: #1D1E25;
 }
+
+.post .notice {
+  padding: 3.5rem;
+  margin-bottom: 2rem;
+  border-left-width: 5px;
+  border-radius: 1.5rem;
+  border-left-style: solid;
+  background-color: var(--bg-secondary);
+}
+
+.post .notice.info {
+  border-color: var(--info);
+}
+
+.post .notice.info h3 {
+  color: var(--info);
+}
+
+.post .notice.warning {
+  border-color: var(--warning);
+}
+
+.post .notice.warning h3 {
+  color: var(--warning);
+}
+
+.post .notice.success {
+  border-color: var(--success);
+}
+
+.post .notice.success h3 {
+  color: var(--success);
+}
+
+.post .notice.danger {
+  border-color: var(--danger);
+}
+
+.post .notice.danger h3 {
+  color: var(--danger);
+}
+
+/* .post .notice p:last-of-type {
+  margin-bottom: unset;
+} */


### PR DESCRIPTION
Add notice block for the post page

Info and Warning notice blocks
<img width="983" alt="Screenshot 2024-01-31 at 21 53 24" src="https://github.com/scherbo/scherbo.com/assets/47299867/28fb3250-98a3-4822-8953-03d8f3e44095">

Success notice block
<img width="983" alt="Screenshot 2024-01-31 at 21 53 31" src="https://github.com/scherbo/scherbo.com/assets/47299867/60f6200b-dc5c-4d9f-a67b-0d30cd577d0d">

Danger notice block
<img width="983" alt="Screenshot 2024-01-31 at 21 53 35" src="https://github.com/scherbo/scherbo.com/assets/47299867/7a749d13-ae0d-4dcd-84ef-60d9e585501a">
